### PR TITLE
9662関係 コンテナのスリム化

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,21 +1,16 @@
 # from docker hub
 FROM centos:centos7.1.1503
 
-MAINTAINER Urasin <urasin2012@gmail.com>
+MAINTAINER Castalia Developers <developers@castalia.co.jp>
 
 # install git
-RUN yum install -y git htop wget curl libxml2-devel libxslt-devel tar patch gcc gcc-c++ yum-utils libffi-devel
+RUN yum install -y git wget curl libxml2-devel libxslt-devel tar patch gcc gcc-c++ yum-utils libffi-devel
 
-# install mysql
-RUN yum install -y http://repo.mysql.com/mysql-community-release-el7-7.noarch.rpm state=present
 RUN rpm --rebuilddb;yum install -y yum-plugin-ovl
 RUN yum swap -y fakesystemd systemd
 
 RUN yum update -y && yum -y install glibc-common && localedef -v -c -i ja_JP -f UTF-8 ja_JP.UTF-8; echo "";
 ENV LANG=ja_JP.UTF-8
-
-RUN yum-config-manager --disable mysql56-community
-RUN yum-config-manager --enable mysql57-community
 
 # install pyenv to root
 RUN git clone https://github.com/yyuu/pyenv.git /root/.pyenv
@@ -25,37 +20,14 @@ RUN echo 'export PATH=$PYENV_ROOT/bin:$PATH' >> /root/.bashrc
 RUN echo 'eval "$(pyenv init -)"' >> /root/.bashrc
 RUN source ~/.bashrc
 
-# install python 2.7.9
+# install python 3.6.1
 RUN yum install -y make zlib-devel bzip2 bzip2-devel readline-devel sqlite-devel openssl-devel libjpeg-devel libselinux-python
-RUN /root/.pyenv/bin/pyenv install 2.7.9
 
-# install ansible
-RUN /root/.pyenv/versions/2.7.9/bin/pip install ansible
-RUN /root/.pyenv/bin/pyenv rehash
-
-# install python 3.5.2
-RUN /root/.pyenv/bin/pyenv install 3.6.1
+RUN /root/.pyenv/bin/pyenv install -v 3.6.1
 RUN /root/.pyenv/bin/pyenv global 3.6.1
+RUN /root/.pyenv/versions/3.6.1/bin/pip install ansible
 RUN /root/.pyenv/bin/pyenv rehash
 RUN /root/.pyenv/shims/pip install --upgrade pip
 RUN /root/.pyenv/shims/pip install wheel
 
-# install Groonga
-RUN yum install -y http://packages.groonga.org/centos/groonga-release-1.3.0-1.noarch.rpm
-RUN yum install -y mysql57-community-mroonga mysql-devel
-
-# install redis
-RUN yum -y install epel-release; yum clean all
-RUN yum -y install redis; yum clean all
-
-# ansibleのため/usr/bin/pythonにsymbolic linkをはる(ansibleはlocal, remoteの/ust/bin/pythonを見るため)
-RUN mv /usr/bin/python /usr/bin/python_bak
-RUN ln -s /root/.pyenv/versions/2.7.9/bin/python /usr/bin/python
-
-RUN rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
-	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
-# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld
-RUN mysqld --user=mysql --initialize-insecure --datadir="/var/lib/mysql"
-
-ENTRYPOINT echo "daemonize yes" > redis.conf && redis-server redis.conf && /usr/sbin/mysqld --daemonize --user=mysql && mysql -uroot -e "INSTALL PLUGIN mroonga SONAME 'ha_mroonga.so';" && /bin/bash
+ENTRYPOINT /bin/bash

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,36 +1,23 @@
-# from docker hub
 FROM python:3.6.1
 
-MAINTAINER Castalia Developers <developers@castalia.co.jp>
+LABEL maintainer="Castalia Developers <developers@castalia.co.jp>"
 
+# install mysql client
+# デフォルトだと mysql-client-5.5 がインストールされるため 5.7 にする
+ENV MYSQL_MAJOR_VERSION 5.7
+ENV MYSQL_APT_CONFIG_PACKAGE mysql-apt-config_0.8.10-1_all.deb
+RUN \
+  apt-get update && apt-get install lsb-release && \
+  wget https://dev.mysql.com/get/${MYSQL_APT_CONFIG_PACKAGE} && \
+  echo mysql-apt-config	mysql-apt-config/select-server	select	mysql-${MYSQL_MAJOR_VERSION} | debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive dpkg -i ${MYSQL_APT_CONFIG_PACKAGE} && \
+  apt-get update && \
+  apt-get install -y mysql-client
 
-# install git
-# RUN yum install -y git wget curl libxml2-devel libxslt-devel tar patch gcc gcc-c++ yum-utils libffi-devel
-
-# RUN rpm --rebuilddb;yum install -y yum-plugin-ovl
-# RUN yum swap -y fakesystemd systemd
-
-# RUN yum update -y && yum -y install glibc-common && localedef -v -c -i ja_JP -f UTF-8 ja_JP.UTF-8; echo "";
-# ENV LANG=ja_JP.UTF-8
-
-# install mysql	client
-RUN apt-get update && apt-get install -y mysql-client libmysqlclient-dev
-
-# install pyenv to root
-# RUN git clone https://github.com/yyuu/pyenv.git /root/.pyenv
-
-# RUN echo 'export PYENV_ROOT=$HOME/.pyenv' >> /root/.bashrc
-# RUN echo 'export PATH=$PYENV_ROOT/bin:$PATH' >> /root/.bashrc
-# RUN echo 'eval "$(pyenv init -)"' >> /root/.bashrc
-# RUN source ~/.bashrc
-
-# install python 3.6.1
-# RUN yum install -y make zlib-devel bzip2 bzip2-devel readline-devel sqlite-devel openssl-devel libjpeg-devel libselinux-python
-
-# RUN /root/.pyenv/bin/pyenv install -v 3.6.1
-# RUN /root/.pyenv/bin/pyenv global 3.6.1
-RUN pip install ansible
 RUN pip install --upgrade pip
 RUN pip install wheel
+
+ENV ANSIBLE_VERSION 2.6.3
+RUN pip install ansible==${ANSIBLE_VERSION}
 
 ENTRYPOINT /bin/bash

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,6 +3,7 @@ FROM centos:centos7.1.1503
 
 MAINTAINER Castalia Developers <developers@castalia.co.jp>
 
+
 # install git
 RUN yum install -y git wget curl libxml2-devel libxslt-devel tar patch gcc gcc-c++ yum-utils libffi-devel
 
@@ -11,6 +12,9 @@ RUN yum swap -y fakesystemd systemd
 
 RUN yum update -y && yum -y install glibc-common && localedef -v -c -i ja_JP -f UTF-8 ja_JP.UTF-8; echo "";
 ENV LANG=ja_JP.UTF-8
+
+# install mysql	client
+RUN rpm -Uvh http://dev.mysql.com/get/mysql-community-release-el7-5.noarch.rpm && yum -y install mysql-community-client
 
 # install pyenv to root
 RUN git clone https://github.com/yyuu/pyenv.git /root/.pyenv

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,37 +1,36 @@
 # from docker hub
-FROM centos:centos7.1.1503
+FROM python:3.6.1
 
 MAINTAINER Castalia Developers <developers@castalia.co.jp>
 
 
 # install git
-RUN yum install -y git wget curl libxml2-devel libxslt-devel tar patch gcc gcc-c++ yum-utils libffi-devel
+# RUN yum install -y git wget curl libxml2-devel libxslt-devel tar patch gcc gcc-c++ yum-utils libffi-devel
 
-RUN rpm --rebuilddb;yum install -y yum-plugin-ovl
-RUN yum swap -y fakesystemd systemd
+# RUN rpm --rebuilddb;yum install -y yum-plugin-ovl
+# RUN yum swap -y fakesystemd systemd
 
-RUN yum update -y && yum -y install glibc-common && localedef -v -c -i ja_JP -f UTF-8 ja_JP.UTF-8; echo "";
-ENV LANG=ja_JP.UTF-8
+# RUN yum update -y && yum -y install glibc-common && localedef -v -c -i ja_JP -f UTF-8 ja_JP.UTF-8; echo "";
+# ENV LANG=ja_JP.UTF-8
 
 # install mysql	client
-RUN rpm -Uvh http://dev.mysql.com/get/mysql-community-release-el7-5.noarch.rpm && yum -y install mysql-community-client
+RUN apt-get update && apt-get install -y mysql-client libmysqlclient-dev
 
 # install pyenv to root
-RUN git clone https://github.com/yyuu/pyenv.git /root/.pyenv
+# RUN git clone https://github.com/yyuu/pyenv.git /root/.pyenv
 
-RUN echo 'export PYENV_ROOT=$HOME/.pyenv' >> /root/.bashrc
-RUN echo 'export PATH=$PYENV_ROOT/bin:$PATH' >> /root/.bashrc
-RUN echo 'eval "$(pyenv init -)"' >> /root/.bashrc
-RUN source ~/.bashrc
+# RUN echo 'export PYENV_ROOT=$HOME/.pyenv' >> /root/.bashrc
+# RUN echo 'export PATH=$PYENV_ROOT/bin:$PATH' >> /root/.bashrc
+# RUN echo 'eval "$(pyenv init -)"' >> /root/.bashrc
+# RUN source ~/.bashrc
 
 # install python 3.6.1
-RUN yum install -y make zlib-devel bzip2 bzip2-devel readline-devel sqlite-devel openssl-devel libjpeg-devel libselinux-python
+# RUN yum install -y make zlib-devel bzip2 bzip2-devel readline-devel sqlite-devel openssl-devel libjpeg-devel libselinux-python
 
-RUN /root/.pyenv/bin/pyenv install -v 3.6.1
-RUN /root/.pyenv/bin/pyenv global 3.6.1
-RUN /root/.pyenv/versions/3.6.1/bin/pip install ansible
-RUN /root/.pyenv/bin/pyenv rehash
-RUN /root/.pyenv/shims/pip install --upgrade pip
-RUN /root/.pyenv/shims/pip install wheel
+# RUN /root/.pyenv/bin/pyenv install -v 3.6.1
+# RUN /root/.pyenv/bin/pyenv global 3.6.1
+RUN pip install ansible
+RUN pip install --upgrade pip
+RUN pip install wheel
 
 ENTRYPOINT /bin/bash


### PR DESCRIPTION
## やったこと

- コンテナのベースをcentos7からpython(中身はubuntu)に変更。Pythonのバージョンを変えたくなった時にすぐに変えられるようにするため(今はPythonをコンパイルしているためコンテナのビルドにかなり時間がかかっている。またコンパイルするために依存ライブラリが多い)
- MySQLサーバ、RedisのインストールをやめMySQLクライアントだけをインストールするよう変更 (wercker の services 機能で別に立てられるため)
- Python 2.7のインストールをやめた(新しめのAnsibleはPython 3に対応しているため)
- `MAINTAINER` は deprecated なので新しい書き方に変更

## チケット

https://redmine.gooc.us/issues/9662

## その他

関連PR https://github.com/CastaliaCoLtd/goocus3-server/pull/1424

* Ansible も別のboxにすればいい気がするけど変更のし過ぎはよろしくないので今回はやらない